### PR TITLE
Fix encoder memory corruption bug

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -29,17 +29,13 @@ extern "C" void app_main()
     rotaryencoder_initialize();
     iotuz_graphics_initialize();
     sensors_initialize();
-
-    // disabled to avoid a race in rotaryencoder.
-    //joystick_initialize();
+    joystick_initialize();
 
     xTaskCreatePinnedToCore(send_telemetry_task, "send_telemetry_task", 4096, NULL, 1, NULL, 1);
     xTaskCreatePinnedToCore(send_sensors_task, "send_sensors_task", 4096, NULL, 1, NULL, 1);
     xTaskCreatePinnedToCore(send_buttons_task, "send_buttons_task", 4096, NULL, 1, NULL, 1);
     xTaskCreatePinnedToCore(send_rotaryencoder_task, "send_rotaryencoder_task", 4096, NULL, 1, NULL, 1);
-
-    // disabled to avoid a race in rotaryencoder.
-    //xTaskCreatePinnedToCore(send_joystick_task, "send_joystick_task", 4096, NULL, 1, NULL, 1);
+    xTaskCreatePinnedToCore(send_joystick_task, "send_joystick_task", 4096, NULL, 1, NULL, 1);
 }
 
 static void send_telemetry_task(void *pvParameter)
@@ -103,7 +99,7 @@ static void send_rotaryencoder_task(void *pvParameter) {
 
 // Subscribe to rotary encoder values ...
 
-    QueueHandle_t rotaryencoder = xQueueCreate(10, sizeof(button_reading_t));
+    QueueHandle_t rotaryencoder = xQueueCreate(10, sizeof(rotaryencoder_reading_t));
 
     if (! rotaryencoder_subscribe(rotaryencoder)) {
         ESP_LOGE(TAG, "Failed to subscribe to button readings :(");


### PR DESCRIPTION
Reverts "Disable the joystick to avoid a interrupt related issue."

This reverts commit 1cedfcf552c83f2ad5803ac7a700d2bc4c7cb95a.