### PR TITLE
sensors: Make readings array large enough

### DIFF
--- a/main/sensors.cpp
+++ b/main/sensors.cpp
@@ -5,7 +5,7 @@
 
 #include "esp_log.h"
 
-static float readings[SENS_MAX-1];
+static float readings[SENS_MAX];
 
 static QueueHandle_t *subscriptions;
 static size_t num_subscriptions;


### PR DESCRIPTION
Don't overrun the end of the readings array - make sure
it's large enough for all sensors